### PR TITLE
Remove Intercom function that's no longer supported

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -16,14 +16,14 @@ RCT_EXPORT_MODULE();
 // Available as NativeModules.IntercomWrapper.registerIdentifiedUser
 RCT_EXPORT_METHOD(registerIdentifiedUser:(NSDictionary*)options callback:(RCTResponseSenderBlock)callback) {
   NSLog(@"registerIdentifiedUser with %@", options);
-  
+
   NSString* userId      = options[@"userId"];
   NSString* userEmail   = options[@"email"];
-  
+
   if ([userId isKindOfClass:[NSNumber class]]) {
     userId = [(NSNumber *)userId stringValue];
   }
-  
+
   if (userId.length > 0 && userEmail.length > 0) {
     [Intercom registerUserWithUserId:userId email:userEmail];
     callback(@[[NSNull null], @[userId]]);
@@ -64,35 +64,35 @@ RCT_EXPORT_METHOD(updateUser:(NSDictionary*)options callback:(RCTResponseSenderB
 // Available as NativeModules.IntercomWrapper.logEvent
 RCT_EXPORT_METHOD(logEvent:(NSString*)eventName metaData:(NSDictionary*)metaData callback:(RCTResponseSenderBlock)callback) {
   NSLog(@"logEvent with %@", eventName);
-  
+
   if (metaData.count > 0) {
     [Intercom logEventWithName:eventName metaData:metaData];
   } else {
     [Intercom logEventWithName:eventName];
   }
-  
+
   callback(@[[NSNull null]]);
 };
 
 // Available as NativeModules.IntercomWrapper.displayMessageComposer
 RCT_EXPORT_METHOD(displayMessageComposer:(RCTResponseSenderBlock)callback) {
   NSLog(@"displayMessageComposer");
-  
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [Intercom presentMessageComposer];
   });
-  
+
   callback(@[[NSNull null]]);
 };
 
 // Available as NativeModules.IntercomWrapper.displayConversationsList
 RCT_EXPORT_METHOD(displayConversationsList:(RCTResponseSenderBlock)callback) {
   NSLog(@"displayConversationsList");
-  
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [Intercom presentConversationList];
   });
-  
+
   callback(@[[NSNull null]]);
 };
 
@@ -131,35 +131,5 @@ RCT_EXPORT_METHOD(setupAPN:(NSString*)deviceToken callback:(RCTResponseSenderBlo
   [Intercom setDeviceToken:[deviceToken dataUsingEncoding:NSUTF8StringEncoding]];
   callback(@[[NSNull null]]);
 };
-
-// Available as NativeModules.IntercomWrapper.registerForPush
-RCT_EXPORT_METHOD(registerForPush:(RCTResponseSenderBlock)callback) {
-  NSLog(@"registerForPush");
-  
-  UIApplication *application = [UIApplication sharedApplication];
-  if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]){ // iOS 8 (User notifications)
-    [application registerUserNotificationSettings:
-     [UIUserNotificationSettings settingsForTypes:
-      (UIUserNotificationTypeBadge |
-       UIUserNotificationTypeSound |
-       UIUserNotificationTypeAlert)
-                                       categories:nil]];
-    [application registerForRemoteNotifications];
-  } else { // iOS 7 (Remote notifications)
-    [application registerForRemoteNotificationTypes:
-     (UIRemoteNotificationType)
-     (UIRemoteNotificationTypeBadge |
-      UIRemoteNotificationTypeSound |
-      UIRemoteNotificationTypeAlert)];
-  }
-  
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [Intercom registerForRemoteNotifications];
-  #pragma GCC diagnostic pop
-
-  callback(@[[NSNull null]]);
-};
-
 
 @end

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -131,18 +131,6 @@ class IntercomClient {
 			});
 		});
 	}
-
-	registerForPush() {
-		return new Promise((resolve, reject) => {
-			IntercomWrapper.registerForPush(function(error) {
-				if (error) {
-					reject(error);
-				} else {
-					resolve()
-				}
-			});
-		});
-	}
 }
 
 module.exports = new IntercomClient();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-intercom",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A React Native client for Intercom.io",
   "main": "./lib/IntercomClient.js",
   "scripts": {


### PR DESCRIPTION
Support for registerForRemoteNotifications was removed in the Intercom
iOS library 2.3.5 and later:

https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md
