### PR TITLE
Fixed the push notification registration according to the latest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ Install
     [Intercom setApiKey:@"<#ios_sdk-...#>" forAppId:@"<#your-app-id#>"];
 }
 ```
+6. [Intercom's documentation](https://github.com/intercom/intercom-ios/blob/1fe2e92c4913e4ffef290b5b62dac5ecef74ea1d/Intercom.framework/Versions/A/Headers/Intercom.h#L65) suggests adding the following call in order to receive push notifications for new messages:
+```
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+     [Intercom setDeviceToken:deviceToken];
+}
+```
 
 Usage
 =====

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -152,11 +152,6 @@ RCT_EXPORT_METHOD(registerForPush:(RCTResponseSenderBlock)callback) {
       UIRemoteNotificationTypeSound |
       UIRemoteNotificationTypeAlert)];
   }
-  
-  #pragma GCC diagnostic push
-  #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    [Intercom registerForRemoteNotifications];
-  #pragma GCC diagnostic pop
 
   callback(@[[NSNull null]]);
 };


### PR DESCRIPTION
Fixes #5 and #1 .

I saw that #3 did a great job fixing this issue, but I think we should keep the `registerForPush` functionality, since it's required for the didRegisterForRemoteNotificationsWithDeviceToken to be called.
