### PR TITLE
Fix intercom registration without userId

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -32,7 +32,7 @@ RCT_EXPORT_METHOD(registerIdentifiedUser:(NSDictionary*)options callback:(RCTRes
         callback(@[[NSNull null], @[userId]]);
     } else if (userEmail.length > 0) {
         [Intercom registerUserWithEmail:userEmail];
-        callback(@[[NSNull null], @[userId]]);
+        callback(@[[NSNull null], @[userEmail]]);
     } else {
         NSLog(@"[Intercom] ERROR - No user registered. You must supply an email, a userId or both");
         callback(@[RCTMakeError(@"Error", nil, nil)]);


### PR DESCRIPTION
Fixes callback function when the intercom registration has only user email.

When I need to register user only with email on intercom, the lib was crashing with an exception the line after the registration occurs, when the callback function to react was called. I just needed to change the callback to use userEmail instead of userId, and it is working now.
