### PR TITLE
Ensure we invoke Intercom.reset on the main thread

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -49,7 +49,11 @@ RCT_EXPORT_METHOD(registerUnidentifiedUser:(RCTResponseSenderBlock)callback) {
 // Available as NativeModules.IntercomWrapper.reset
 RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock)callback) {
     NSLog(@"reset");
-    [Intercom reset];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Intercom reset];
+    });
+    
     callback(@[[NSNull null]]);
 };
 


### PR DESCRIPTION
I've gotten several exceptions via bugsnag complaining:

```
RCTFatalException: Exception 'Only run on the main thread!' was thrown while invoking reset on target IntercomWrapper with params (
    7
) Exception 'Only run on the main thread!' was thrown while invoking reset on...
```

This seems like it would fix it. Though perhaps we should also wrap the rest of Intercom invocations to ensure we're on the main thread.
