### PR TITLE
Fix unreadConversationCount -> getUnreadConversationCount

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -20,6 +20,7 @@ import javax.annotation.Nullable;
 
 import io.intercom.android.sdk.Intercom;
 import io.intercom.android.sdk.identity.Registration;
+import io.intercom.android.sdk.preview.IntercomPreviewPosition;
 
 public class IntercomModule extends ReactContextBaseJavaModule {
 
@@ -109,6 +110,12 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void hideMessenger(Callback callback) {
+        Intercom.client().hideMessenger();
+        callback.invoke(null, null);
+    }
+
+    @ReactMethod
     public void displayMessageComposer(Callback callback) {
         Intercom.client().displayMessageComposer();
         callback.invoke(null, null);
@@ -133,18 +140,33 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         }
     }
 
+    private Intercom.Visibility visibilityStringToVisibility(String visibility) {
+      if (visibility.equalsIgnoreCase("VISIBLE")) {
+        return Intercom.Visibility.VISIBLE;
+      } else {
+        return Intercom.Visibility.GONE;
+      }
+    }
+
     @ReactMethod
-    public void setLauncherVisible(String visibility, Callback callback) {
-        Intercom.Visibility intercomVisibility = Intercom.Visibility.VISIBLE;
-        if (visibility.equalsIgnoreCase("VISIBLE")) {
-            intercomVisibility = Intercom.Visibility.VISIBLE;
-        }
-        if (visibility.equalsIgnoreCase("GONE")) {
-            intercomVisibility = Intercom.Visibility.GONE;
-        }
+    public void setLauncherVisibility(String visibility, Callback callback) {
+        Intercom.Visibility intercomVisibility = visibilityStringToVisibility(visibility);
 
         try {
             Intercom.client().setLauncherVisibility(intercomVisibility);
+
+            callback.invoke(null);
+        } catch (Exception ex) {
+            callback.invoke(ex.toString());
+        }
+    }
+
+    @ReactMethod
+    public void setInAppMessageVisibility(String visibility, Callback callback) {
+        Intercom.Visibility intercomVisibility = visibilityStringToVisibility(visibility);
+
+        try {
+            Intercom.client().setInAppMessageVisibility(intercomVisibility);
 
             callback.invoke(null);
         } catch (Exception ex) {
@@ -189,7 +211,7 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         List<Object> deconstructedList = new ArrayList<>(readableArray.size());
         for (int i = 0; i < readableArray.size(); i++) {
             ReadableType indexType = readableArray.getType(i);
-            switch (indexType) {
+            switch(indexType) {
                 case Null:
                     deconstructedList.add(i, null);
                     break;

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -16,14 +16,14 @@ RCT_EXPORT_MODULE();
 // Available as NativeModules.IntercomWrapper.registerIdentifiedUser
 RCT_EXPORT_METHOD(registerIdentifiedUser:(NSDictionary*)options callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"registerIdentifiedUser with %@", options);
-    
+
     NSString* userId      = options[@"userId"];
     NSString* userEmail   = options[@"email"];
-    
+
     if ([userId isKindOfClass:[NSNumber class]]) {
         userId = [(NSNumber *)userId stringValue];
     }
-    
+
     if (userId.length > 0 && userEmail.length > 0) {
         [Intercom registerUserWithUserId:userId email:userEmail];
         callback(@[[NSNull null], @[userId]]);
@@ -49,11 +49,11 @@ RCT_EXPORT_METHOD(registerUnidentifiedUser:(RCTResponseSenderBlock)callback) {
 // Available as NativeModules.IntercomWrapper.reset
 RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock)callback) {
     NSLog(@"reset");
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [Intercom reset];
     });
-    
+
     callback(@[[NSNull null]]);
 };
 
@@ -68,67 +68,90 @@ RCT_EXPORT_METHOD(updateUser:(NSDictionary*)options callback:(RCTResponseSenderB
 // Available as NativeModules.IntercomWrapper.logEvent
 RCT_EXPORT_METHOD(logEvent:(NSString*)eventName metaData:(NSDictionary*)metaData callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"logEvent with %@", eventName);
-    
+
     if (metaData.count > 0) {
         [Intercom logEventWithName:eventName metaData:metaData];
     } else {
         [Intercom logEventWithName:eventName];
     }
-    
+
     callback(@[[NSNull null]]);
 };
 
 // Available as NativeModules.IntercomWrapper.displayMessenger
 RCT_EXPORT_METHOD(displayMessenger:(RCTResponseSenderBlock)callback) {
     NSLog(@"displayMessenger");
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [Intercom presentMessenger];
     });
-    
+
+    callback(@[[NSNull null]]);
+}
+
+// Available as NativeModules.IntercomWrapper.hideMessenger
+RCT_EXPORT_METHOD(hideMessenger:(RCTResponseSenderBlock)callback) {
+    NSLog(@"hideMessenger");
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Intercom hideMessenger];
+    });
+
     callback(@[[NSNull null]]);
 }
 
 // Available as NativeModules.IntercomWrapper.displayMessageComposer
 RCT_EXPORT_METHOD(displayMessageComposer:(RCTResponseSenderBlock)callback) {
     NSLog(@"displayMessageComposer");
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [Intercom presentMessageComposer];
     });
-    
+
     callback(@[[NSNull null]]);
 };
 
 // Available as NativeModules.IntercomWrapper.displayConversationsList
 RCT_EXPORT_METHOD(displayConversationsList:(RCTResponseSenderBlock)callback) {
     NSLog(@"displayConversationsList");
-    
+
     dispatch_async(dispatch_get_main_queue(), ^{
         [Intercom presentConversationList];
     });
-    
+
     callback(@[[NSNull null]]);
 };
 
 // Available as NativeModules.IntercomWrapper.getUnreadConversationCount
 RCT_EXPORT_METHOD(getUnreadConversationCount:(RCTResponseSenderBlock)callback) {
     NSLog(@"getUnreadConversationCount");
-    
+
     NSNumber *unread_conversations = [NSNumber numberWithUnsignedInteger:[Intercom unreadConversationCount]];
-    
+
     callback(@[[NSNull null], unread_conversations]);
 }
 
-// Available as NativeModules.IntercomWrapper.setLauncherVisible
-RCT_EXPORT_METHOD(setLauncherVisible:(NSString*)visibilityString callback:(RCTResponseSenderBlock)callback) {
+// Available as NativeModules.IntercomWrapper.setLauncherVisibility
+RCT_EXPORT_METHOD(setLauncherVisibility:(NSString*)visibilityString callback:(RCTResponseSenderBlock)callback) {
+    NSLog(@"setVisibility with %@", visibilityString);
+    BOOL visible = NO;
+    if ([visibilityString isEqualToString:@"GONE"]) {
+        visible = YES;
+    }
+    [Intercom setLauncherVisible:visible];
+
+    callback(@[[NSNull null]]);
+};
+
+// Available as NativeModules.IntercomWrapper.setInAppMessageVisibility
+RCT_EXPORT_METHOD(setInAppMessageVisibility:(NSString*)visibilityString callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"setVisibility with %@", visibilityString);
     BOOL visible = YES;
     if ([visibilityString isEqualToString:@"GONE"]) {
         visible = NO;
     }
-    [Intercom setLauncherVisible:visible];
-    
+    [Intercom setInAppMessagesVisible:visible];
+
     callback(@[[NSNull null]]);
 };
 
@@ -142,7 +165,7 @@ RCT_EXPORT_METHOD(setupAPN:(NSString*)deviceToken callback:(RCTResponseSenderBlo
 // Available as NativeModules.IntercomWrapper.registerForPush
 RCT_EXPORT_METHOD(registerForPush:(RCTResponseSenderBlock)callback) {
     NSLog(@"registerForPush");
-    
+
     UIApplication *application = [UIApplication sharedApplication];
     if ([application respondsToSelector:@selector(registerUserNotificationSettings:)]){ // iOS 8 (User notifications)
         [application registerUserNotificationSettings:
@@ -159,7 +182,7 @@ RCT_EXPORT_METHOD(registerForPush:(RCTResponseSenderBlock)callback) {
           UIRemoteNotificationTypeSound |
           UIRemoteNotificationTypeAlert)];
     }
-    
+
     callback(@[[NSNull null]]);
 };
 

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -23,7 +23,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -35,7 +35,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -47,7 +47,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -59,7 +59,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -71,7 +71,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -85,7 +85,19 @@ class IntercomClient {
 				} else {
 					resolve();
 				}
-			})
+			});
+		});
+	}
+
+	hideMessenger() {
+		return new Promise((resolve, reject) => {
+			IntercomWrapper.hideMessenger(function(error) {
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			});
 		});
 	}
 
@@ -95,7 +107,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -107,15 +119,15 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
 	}
 
-	unreadConversationCount() {
+	getUnreadConversationCount() {
 		return new Promise((resolve, reject) => {
-			IntercomWrapper.unreadConversationCount(function(count, error) {
+			IntercomWrapper.getUnreadConversationCount(function(error, count) {
 				if (error) {
 					reject(error);
 				} else {
@@ -125,15 +137,27 @@ class IntercomClient {
 		});
 	}
 
-	setLauncherVisible(visiblity: bool) {
+	setLauncherVisibility(visibility: String) {
 		return new Promise((resolve, reject) => {
-			IntercomWrapper.setLauncherVisible(visiblity, function(error) {
+			IntercomWrapper.setLauncherVisibility(visibility, function(error) {
 				if (error) {
 					reject(error);
 				} else {
 					resolve();
 				}
-			})
+			});
+		});
+	}
+
+	setInAppMessageVisibility(visibility: String) {
+		return new Promise((resolve, reject) => {
+			IntercomWrapper.setInAppMessageVisibility(visibility, function(error) {
+				if (error) {
+					reject(error);
+				} else {
+					resolve()
+				}
+			});
 		});
 	}
 
@@ -143,7 +167,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -155,7 +179,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});
@@ -167,7 +191,7 @@ class IntercomClient {
 				if (error) {
 					reject(error);
 				} else {
-					resolve()
+					resolve();
 				}
 			});
 		});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-intercom",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A React Native client for Intercom.io",
   "main": "./lib/IntercomClient.js",
   "scripts": {


### PR DESCRIPTION
Rename methods:
  setLauncherVisible -> setLauncherVisibility

Add methods:
  hideMessenger
  setInAppMessageVisibility

These changes are to keep with the current pattern of tracking the
android intercom API, translating the iOS to match.

Also, add some linted semicolons.

Fixes most of #27, although we still need support for unread conversation count listeners
