### PR TITLE
Reduce minimum version of iOS to 8.0, same as the Intercom library

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.summary      = package['description']
   s.source       = { :git => package['repository']['url'] }
   s.source_files = 'iOS/*.{h,m}'
-  s.platform     = :ios, '8.2'
+  s.platform     = :ios, '8.0'
   s.frameworks   = [ "Intercom" ]
 
   s.dependency 'Intercom', '> 3'


### PR DESCRIPTION
Hi there, thanks for making this library!

I noticed the version was set to 8.2...was there are particular reason for that? I was able to use 8.0 on our app (same min version as the native Intercom library).

Cheers!
