### PR TITLE
Fix mistaken logic in setLauncherVisibility for ios

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -135,7 +135,7 @@ RCT_EXPORT_METHOD(getUnreadConversationCount:(RCTResponseSenderBlock)callback) {
 RCT_EXPORT_METHOD(setLauncherVisibility:(NSString*)visibilityString callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"setVisibility with %@", visibilityString);
     BOOL visible = NO;
-    if ([visibilityString isEqualToString:@"GONE"]) {
+    if ([visibilityString isEqualToString:@"VISIBLE"]) {
         visible = YES;
     }
     [Intercom setLauncherVisible:visible];


### PR DESCRIPTION
I noticed that the logic seems a bit backward here. We actually want the launcher to be visible when we pass in the `visible` arg. 
