### PR TITLE
Fix to event emitter listener removal... oops.

### DIFF
--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -21,6 +21,7 @@ class IntercomClient {
 		UNREAD_COUNT: IntercomEventEmitter.UNREAD_CHANGE_NOTIFICATION,
 	}
 
+	_eventEmitter;
   	_eventHandlers;
 
 	constructor() {
@@ -222,11 +223,12 @@ class IntercomClient {
 	}
 
 	addEventListener(type, handler) {
-    	const ee = new NativeEventEmitter(IntercomEventEmitter);
-		ee.addListener(type, rtn => {
-			handler(rtn)
-		});
-		this._eventHandlers[type].set(handler, ee);
+		if (!this._eventEmitter) {
+			this._eventEmitter = new NativeEventEmitter(IntercomEventEmitter);
+		}
+
+		const listener = this._eventEmitter.addListener(type, rtn => handler(rtn));
+		this._eventHandlers[type].set(handler, listener);
   	}
 
 	removeEventListener (type, handler) {


### PR DESCRIPTION
Was throwing an error on removeEventListener... My bad :(
This fix adds the listener to the map, not the emitter itself. 