### PR TITLE
Add Android handlePushMessage method

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -103,6 +103,12 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void handlePushMessage(Callback callback) {
+        Intercom.client().handlePushMessage();
+        callback.invoke(null, null);
+    }
+
+    @ReactMethod
     public void displayMessenger(Callback callback) {
         Intercom.client().displayMessenger();
         callback.invoke(null, null);

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -78,6 +78,15 @@ RCT_EXPORT_METHOD(logEvent:(NSString*)eventName metaData:(NSDictionary*)metaData
     callback(@[[NSNull null]]);
 };
 
+// Available as NativeModules.IntercomWrapper.handlePushMessage
+RCT_EXPORT_METHOD(handlePushMessage:(RCTResponseSenderBlock)callback) {
+    NSLog(@"handlePushMessage");
+
+    // This is a stub. The iOS Intercom client automatically handles push notifications
+
+    callback(@[[NSNull null]]);
+}
+
 // Available as NativeModules.IntercomWrapper.displayMessenger
 RCT_EXPORT_METHOD(displayMessenger:(RCTResponseSenderBlock)callback) {
     NSLog(@"displayMessenger");

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -90,6 +90,18 @@ class IntercomClient {
 		});
 	}
 
+	handlePushMessage() {
+		return new Promise((resolve, reject) => {
+			IntercomWrapper.handlePushMessage(function(error) {
+				if (error) {
+					reject(error);
+				} else {
+					resolve();
+				}
+			});
+		});
+	}
+
 	displayMessenger() {
 		return new Promise((resolve, reject) => {
 			IntercomWrapper.displayMessenger(function(error) {


### PR DESCRIPTION
The [Intercom docs for Android push messages](https://developers.intercom.com/docs/android-fcm-push-notifications) require a call to `handlePushMessage` after the app has been initialized. This method was not included, so I added it.