### PR TITLE
Remove React dependency in Podfile

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,4 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
 
   s.dependency 'Intercom', '> 3'
-  s.dependency 'React'
 end


### PR DESCRIPTION
The React pod is deprecated:
https://cocoapods.org/pods/React

I am really not sure why this was needed in the first place.