### PR TITLE
Fix header search path for RN@0.36.0

### DIFF
--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**/**",
+					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -240,6 +241,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../../react-native/React/**/**",
+					"$(SRCROOT)/../../react-native/React/**",
 				);
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
As mentioned in #72, RCTBridgeModule.h is not found with only `react-native/React/**/**` in the search path. Adding `react-native/React/**` as well makes it work.

This was not tested for RN >= 0.40.0