### PR TITLE
Intercom-Android 3.1.0 broke compat with SDK v23

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.15.+'
-    compile ('io.intercom.android:intercom-sdk-base:3.+')
+    compile 'io.intercom.android:intercom-sdk-base:3.0.+'
 }


### PR DESCRIPTION
Intercom-Android has just released version 3.1.0. In our brief compat testing, we've noticed it's now requiring `android:TextAppearance.Material.Widget.Button.Borderless.Colored` which doesn't seem to be available in the SDK version used by the latest version of React Native.

This commit pins the Intercom SDK version to `3.0.+` so things keep working.

Maybe this isn't the right fix and the Intercom SDK should fix their release so that the version change reflects backwards compatibility characteristics, but for now it's the best we have.