### PR TITLE
Fixing timing issues on unreadConversationCount event emitter

### DIFF
--- a/iOS/IntercomEventEmitter.m
+++ b/iOS/IntercomEventEmitter.m
@@ -14,8 +14,12 @@
 RCT_EXPORT_MODULE();
 
 - (void)handleUpdateUnreadCount:(NSNotification *)notification {
-    
-    [self sendEventWithName:IntercomUnreadConversationCountDidChangeNotification body:@{@"count": [NSNumber numberWithUnsignedInteger: [Intercom unreadConversationCount]]}];
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+        NSUInteger unreadCount = [Intercom unreadConversationCount];
+        NSNumber *unreadCountNumber = [NSNumber numberWithUnsignedInteger: unreadCount];
+        NSDictionary *body = @{@"count": unreadCountNumber};
+        [self sendEventWithName:IntercomUnreadConversationCountDidChangeNotification body:body];
+    });
 }
 
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {
@@ -27,11 +31,16 @@ RCT_EXPORT_MODULE();
 }
 
 -(void)startObserving {
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUpdateUnreadCount:) name:IntercomUnreadConversationCountDidChangeNotification object:nil];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUpdateUnreadCount:) name:IntercomUnreadConversationCountDidChangeNotification object:nil];
+    });
 }
 
 - (void)stopObserving {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] removeObserver:self];
+    });
 }
 
 @end
+


### PR DESCRIPTION
Just on release builds, we encountered the issue, that the body of the `IntercomUnreadConversationCountDidChangeNotification` event was invalid.

We investigated the issue by creating an App with a bundled `main.jsbundle`, running on a real device, just debugging the objc code in `IntercomEventEmitter.m`.

We realised that whenever `[Intercom unreadConversationCount]` was accessed directly after `- (void)handleUpdateUnreadCount:(NSNotification *)notification {` was called, we didn't get a valid value. 

If we set a breakpoint or a `NSLog` before, we got the correct value. 

Our current solution is to wait for 0.1 seconds until `[Intercom unreadConversationCount]` is called. 

Furthermore we are dispatching `[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUpdateUnreadCount:) name:IntercomUnreadConversationCountDidChangeNotification object:nil];` and `[[NSNotificationCenter defaultCenter] removeObserver:self];` to the main queue - just to be sure. Propably this is not necessary.

Thanks for the great wrapper and we hope we can help a little bit to improve it.
If there are questions, just ask :-)