### PR TITLE
add setUserHash

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -133,6 +133,12 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
+    public void setUserHash(String userHash, Callback callback) {
+        Intercom.client().setUserHash(userHash);
+        callback.invoke(null, null);
+    }
+
+    @ReactMethod
     public void setHMAC(String hmac, String data, Callback callback) {
         Intercom.client().setSecureMode(hmac, data);
         callback.invoke(null, null);

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -211,6 +211,12 @@ RCT_EXPORT_METHOD(setHMAC:(NSString*)hmac data:(NSString*)data callback:(RCTResp
     callback(@[[NSNull null]]);
 };
 
+// Available as NativeModules.IntercomWrapper.setUserHash
+RCT_EXPORT_METHOD(setUserHash:(NSString*)userHash callback:(RCTResponseSenderBlock)callback) {
+    [Intercom setUserHash:userHash];
+    callback(@[[NSNull null]]);
+};
+
 // Available as NativeModules.IntercomWrapper.setBottomPadding
 RCT_EXPORT_METHOD(setBottomPadding:(CGFloat)padding callback:(RCTResponseSenderBlock)callback) {
     [Intercom setBottomPadding:padding];

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -234,6 +234,18 @@ class IntercomClient {
 		});
 	}
 
+  setUserHash(userHash) {
+    return new Promise((resolve, reject) => {
+      IntercomWrapper.setUserHash(userHash, function(error) {
+        if (error) {
+          reject(error);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
 	setBottomPadding(padding) {
 		return new Promise((resolve, reject) => {
 			IntercomWrapper.setBottomPadding(padding, function(error) {


### PR DESCRIPTION
`setHMAC` has been deprecated and `setUserHash` should be used instead: https://github.com/intercom/intercom-ios/blob/master/Intercom.framework/Headers/Intercom.h#L110

This PR adds `setUserHash` method for iOS and Android.

Intercom library required is 3.2.0, which will satisfy the podspec dependency definition, but make sure to `pod repo update` before `pod install` so it will find the latest version published by Intercom.