### PR TITLE
Fix intercom version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.15.+'
-    compile 'io.intercom.android:intercom-sdk-gcm:3.1.+'
+    compile 'io.intercom.android:intercom-sdk-gcm:3.+'
 }


### PR DESCRIPTION
This fixes the problem with the userHash method https://github.com/tinycreative/react-native-intercom/issues/91

Also it can only works with build tools 25 in `app/build.gradle`.

```
android {
    compileSdkVersion 25
    buildToolsVersion "25.0.2"
```

I have to admit that I'm a bit lost about the impact of building with a newer version of the build tools since they are not officially supported by React Native.