### PR TITLE
Use generic react native version to avoid duplicates

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -33,6 +33,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.15.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'io.intercom.android:intercom-sdk-gcm:3.1.+'
 }


### PR DESCRIPTION
Using a specified `react-native` version in `build.gradle` actually make gradle to include multiple versions.
![image](https://cloud.githubusercontent.com/assets/7029942/25810247/69e17656-3407-11e7-87b3-43325da6a6f2.png)
![image](https://cloud.githubusercontent.com/assets/7029942/25810175/35ce5d48-3407-11e7-9b11-ebf760bc999b.png)
