### PR TITLE
Use base library to prevent fcm conflicts

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,5 +34,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:0.15.+'
-    compile 'io.intercom.android:intercom-sdk-gcm:3.1.+'
+    compile 'io.intercom.android:intercom-sdk-base:3.+'
 }


### PR DESCRIPTION
Fixes: #95
Introduced by: https://github.com/tinycreative/react-native-intercom/commit/13bc8b6982ec64dca518f42634d9676fe130dae4

Compiles with the base sdk. Users of this library can choose which push library they use gcm/fcm.