### PR TITLE
Remove createJSModules @ovveride - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
@@ -25,11 +25,6 @@ public class IntercomPackage implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.<ViewManager>asList();
     }

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
@@ -23,6 +23,10 @@ public class IntercomPackage implements ReactPackage {
         modules.add(new IntercomEventEmitter(reactContext));
         return modules;
     }
+    
+    public List<Class<? extends JavaScriptModule>> createJSModules() {		
+        return Collections.emptyList();		
+    }
 
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
@@ -23,10 +23,10 @@ public class IntercomPackage implements ReactPackage {
         modules.add(new IntercomEventEmitter(reactContext));
         return modules;
     }
-    
+
     // Deprecated RN 0.47
-    public List<Class<? extends JavaScriptModule>> createJSModules() {		
-        return Collections.emptyList();		
+    public List<Class<? extends JavaScriptModule>> createJSModules() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomPackage.java
@@ -24,6 +24,7 @@ public class IntercomPackage implements ReactPackage {
         return modules;
     }
     
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {		
         return Collections.emptyList();		
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker.