### PR TITLE
Update to use the  user attributes instead on Map for Android

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 
 import io.intercom.android.sdk.Intercom;
+import io.intercom.android.sdk.UserAttributes;
 import io.intercom.android.sdk.identity.Registration;
 import io.intercom.android.sdk.push.IntercomPushClient;
 
@@ -220,11 +221,11 @@ public class IntercomModule extends ReactContextBaseJavaModule {
 
     private UserAttributes convertToUserAttributes(ReadableMap readableMap) {
         Map<String, Object> map = recursivelyDeconstructReadableMap(readableMap);
-        UserAttributes userAttributes = new UserAttributes.Builder();
+        UserAttributes.Builder builder = new UserAttributes.Builder();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
-            userAttributes.withCustomAttribute(entry.getKey(), entry.getValue());
+            builder.withCustomAttribute(entry.getKey(), entry.getValue());
         }
-        return userAttributes.build();
+        return builder.build();
     }
 
 

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -220,7 +220,7 @@ public class IntercomModule extends ReactContextBaseJavaModule {
 
     private UserAttributes convertToUserAttributes(ReadableMap readableMap) {
         Map<String, Object> map = recursivelyDeconstructReadableMap(readableMap);
-        UserAttributes userAttributes = new UserAttributes.Builder()
+        UserAttributes userAttributes = new UserAttributes.Builder();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
             userAttributes.withCustomAttribute(entry.getKey(), entry.getValue());
         }

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -88,8 +88,8 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void updateUser(ReadableMap options, Callback callback) {
         try {
-            Map<String, Object> map = recursivelyDeconstructReadableMap(options);
-            Intercom.client().updateUser(map);
+            UserAttributes userAttributes = convertToUserAttributes(options);
+            Intercom.client().updateUser(userAttributes);
             Log.i(TAG, "updateUser");
             callback.invoke(null, null);
         } catch (Exception e) {
@@ -216,6 +216,15 @@ public class IntercomModule extends ReactContextBaseJavaModule {
          Intercom.client().setBottomPadding(padding);
          Log.i(TAG, "setBottomPadding");
          callback.invoke(null, null);
+    }
+
+    private UserAttributes convertToUserAttributes(ReadableMap readableMap) {
+        Map<String, Object> map = recursivelyDeconstructReadableMap(readableMap);
+        UserAttributes userAttributes = new UserAttributes.Builder()
+        for (Map.Entry<String, Object> entry : map.entrySet()) {
+            userAttributes.withCustomAttribute(entry.getKey(), entry.getValue());
+        }
+        return userAttributes.build();
     }
 
 


### PR DESCRIPTION
The `updateUser(Map<String, ?> attributes)` method was deprecated in Intercom SDK since version 3.1.0. This uses the new API

Fixes #123 