### PR TITLE
Compatibility with 4.1.0 for iOS

### DIFF
--- a/iOS/IntercomUserAttributesBuilder.h
+++ b/iOS/IntercomUserAttributesBuilder.h
@@ -1,0 +1,16 @@
+//
+//  IntercomUserAttributesBuilder.h
+//  RNIntercom
+//
+//  Created by James Treanor on 09/10/2017.
+//  Copyright © 2017 Jason Brown. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+@class ICMUserAttributes;
+
+@interface IntercomUserAttributesBuilder : NSObject
+
++ (ICMUserAttributes *)userAttributesFromDictionary:(NSDictionary *)attributesDict;
+
+@end

--- a/iOS/IntercomUserAttributesBuilder.m
+++ b/iOS/IntercomUserAttributesBuilder.m
@@ -1,0 +1,109 @@
+//
+//  IntercomUserAttributesBuilder.m
+//  RNIntercom
+//
+//  Created by James Treanor on 09/10/2017.
+//  Copyright © 2017 Jason Brown. All rights reserved.
+//
+
+#import "IntercomUserAttributesBuilder.h"
+#import <Intercom/Intercom.h>
+
+@implementation IntercomUserAttributesBuilder
+
++ (ICMUserAttributes *)userAttributesFromDictionary:(NSDictionary *)attributesDict {
+    ICMUserAttributes *attributes = [ICMUserAttributes new];
+    if ([self stringValueForKey:@"email" inDictionary:attributesDict]) {
+        attributes.email = [self stringValueForKey:@"email" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"user_id" inDictionary:attributesDict]) {
+        attributes.userId = [self stringValueForKey:@"user_id" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"name" inDictionary:attributesDict]) {
+        attributes.name = [self stringValueForKey:@"name" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"phone" inDictionary:attributesDict]) {
+        attributes.phone = [self stringValueForKey:@"phone" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"language_override" inDictionary:attributesDict]) {
+        attributes.languageOverride = [self stringValueForKey:@"language_override" inDictionary:attributesDict];
+    }
+    if ([self dateValueForKey:@"signed_up_at" inDictionary:attributesDict]) {
+        attributes.signedUpAt = [self dateValueForKey:@"signed_up_at" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"unsubscribed_from_emails" inDictionary:attributesDict]) {
+        attributes.unsubscribedFromEmails = [self stringValueForKey:@"unsubscribed_from_emails" inDictionary:attributesDict];
+    }
+    if (attributesDict[@"custom_attributes"]) {
+        attributes.customAttributes = attributesDict[@"custom_attributes"];
+    }
+    if (attributesDict[@"companies"]) {
+        NSMutableArray<ICMCompany *> *companies = [NSMutableArray new];
+        for (NSDictionary *companyDict in attributesDict[@"companies"]) {
+            [companies addObject:[self companyForDictionary:companyDict]];
+        }
+        attributes.companies = companies;
+    }
+    return attributes;
+}
+
++ (ICMCompany *)companyForDictionary:(NSDictionary *)attributesDict {
+    ICMCompany *company = [ICMCompany new];
+    if ([self stringValueForKey:@"company_id" inDictionary:attributesDict]) {
+        company.companyId = [self stringValueForKey:@"company_id" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"name" inDictionary:attributesDict]) {
+        company.name = [self stringValueForKey:@"name" inDictionary:attributesDict];
+    }
+    if ([self dateValueForKey:@"created_at" inDictionary:attributesDict]) {
+        company.createdAt = [self dateValueForKey:@"created_at" inDictionary:attributesDict];
+    }
+    if ([self numberValueForKey:@"monthly_spend" inDictionary:attributesDict]) {
+        company.monthlySpend = [self numberValueForKey:@"monthly_spend" inDictionary:attributesDict];
+    }
+    if ([self stringValueForKey:@"plan" inDictionary:attributesDict]) {
+        company.plan = [self stringValueForKey:@"plan" inDictionary:attributesDict];
+    }
+    if (attributesDict[@"custom_attributes"]) {
+        company.customAttributes = attributesDict[@"custom_attributes"];
+    }
+    return company;
+}
+
++ (NSString *)stringValueForKey:(NSString *)key inDictionary:(NSDictionary *)dictionary {
+    NSString *value = dictionary[key];
+    if ([value isKindOfClass:[NSString class]]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return [NSString stringWithFormat:@"%@", value];
+    }
+    if ([value isKindOfClass:[NSNull class]]) {
+        return [ICMUserAttributes nullStringAttribute];
+    }
+    return nil;
+}
+
++ (NSNumber *)numberValueForKey:(NSString *)key inDictionary:(NSDictionary *)dictionary {
+    NSNumber *value = dictionary[key];
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return value;
+    }
+    if ([value isKindOfClass:[NSNull class]]) {
+        return [ICMUserAttributes nullNumberAttribute];
+    }
+    return nil;
+}
+
++ (NSDate *)dateValueForKey:(NSString *)key inDictionary:(NSDictionary *)dictionary {
+    NSNumber *value = dictionary[key];
+    if ([value isKindOfClass:[NSNumber class]]) {
+        return [NSDate dateWithTimeIntervalSince1970:[value doubleValue]];
+    }
+    if ([value isKindOfClass:[NSNull class]]) {
+        return [ICMUserAttributes nullDateAttribute];
+    }
+    return nil;
+}
+
+@end

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -7,6 +7,7 @@
 //
 
 #import "IntercomWrapper.h"
+#import "IntercomUserAttributesBuilder.h"
 #import <Intercom/Intercom.h>
 
 @implementation IntercomWrapper
@@ -73,11 +74,7 @@ RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock)callback) {
 RCT_EXPORT_METHOD(updateUser:(NSDictionary*)options callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"updateUser with %@", options);
     NSDictionary* attributes = options;
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    // TODO: use updateUser:
-    [Intercom updateUserWithAttributes:attributes];
-#pragma clang diagnostic pop
+    [Intercom updateUser:[IntercomUserAttributesBuilder userAttributesFromDictionary:attributes]];
     callback(@[[NSNull null]]);
 };
 

--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		112EE3851CC0AD7F00BF6BB8 /* IntercomWrapper.m in Sources */ = {isa = PBXBuildFile; fileRef = 112EE3841CC0AD7F00BF6BB8 /* IntercomWrapper.m */; };
+		1AA685A51F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 1AA685A41F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.m */; };
 		DBAD3D711DCC26660027674C /* IntercomEventEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = DBAD3D701DCC26660027674C /* IntercomEventEmitter.m */; };
 /* End PBXBuildFile section */
 
@@ -27,6 +28,8 @@
 		112EE36D1CC0AB8A00BF6BB8 /* libRNIntercom.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNIntercom.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		112EE3831CC0AD7F00BF6BB8 /* IntercomWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntercomWrapper.h; sourceTree = "<group>"; };
 		112EE3841CC0AD7F00BF6BB8 /* IntercomWrapper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntercomWrapper.m; sourceTree = "<group>"; };
+		1AA685A31F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = IntercomUserAttributesBuilder.h; sourceTree = "<group>"; };
+		1AA685A41F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = IntercomUserAttributesBuilder.m; sourceTree = "<group>"; };
 		DBAD3D6F1DCC26660027674C /* IntercomEventEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = IntercomEventEmitter.h; sourceTree = "<group>"; };
 		DBAD3D701DCC26660027674C /* IntercomEventEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = IntercomEventEmitter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -46,6 +49,8 @@
 			isa = PBXGroup;
 			children = (
 				112EE36E1CC0AB8A00BF6BB8 /* Products */,
+				1AA685A31F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.h */,
+				1AA685A41F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.m */,
 				DBAD3D6F1DCC26660027674C /* IntercomEventEmitter.h */,
 				DBAD3D701DCC26660027674C /* IntercomEventEmitter.m */,
 				112EE3831CC0AD7F00BF6BB8 /* IntercomWrapper.h */,
@@ -118,6 +123,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DBAD3D711DCC26660027674C /* IntercomEventEmitter.m in Sources */,
+				1AA685A51F8BFD1B00B92A4E /* IntercomUserAttributesBuilder.m in Sources */,
 				112EE3851CC0AD7F00BF6BB8 /* IntercomWrapper.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.frameworks   = [ "Intercom" ]
 
-  s.dependency 'Intercom', '> 3'
+  s.dependency 'Intercom', '~> 4.1.0'
 end


### PR DESCRIPTION
This adds compatibility with 4.1.0 of Intercom for iOS. It updates the wrapper to use `+[Intercom updateUser:]`. Implementation is taken from https://github.com/intercom/intercom-cordova/blob/master/intercom-plugin/src/ios/IntercomBridge.m.

It also fixes https://github.com/tinycreative/react-native-intercom/issues/134.

P.S. I'm one of the engineers working on Intercom's iOS and Android Messengers so let me know if you have any Intercom-specific questions.