### PR TITLE
 Fix bug while using UserAttribute.Builder in Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,22 @@ Intercom.registerIdentifiedUser({ userId: 'bob' });
 ```javascript
 Intercom.registerIdentifiedUser({ userId: 'bob' })
 Intercom.updateUser({
-		email: 'email',
-		name: 'name',
-	});
+    // Pre-defined user attributes
+    // (this attributes will be added in custom_attributes as duplicate)
+    email: 'mimi@intercom.com',
+    user_id: 'user_id',
+    name: 'your name',
+    phone: '010-1234-5678',
+    language_override: 'language_override',
+    signed_up_at: 1004,
+    unsubscribed_from_emails: true,
+    companies: [{
+        // Only supported for iOS now
+        // Parameters: IntercomUserAttribtesBuilder.m -> companyForDictionary()
+    }],
+    // Other custom_attributes
+    ... 
+});
 ```
 
 ### Sign Out

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ Intercom.updateUser({
         // Only supported for iOS now
         // Parameters: IntercomUserAttribtesBuilder.m -> companyForDictionary()
     }],
-    // Other custom_attributes
-    ... 
+    custom_attributes: {
+        my_custom_attribute: 123
+    },
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ Intercom.registerIdentifiedUser({ userId: 'bob' });
 Intercom.registerIdentifiedUser({ userId: 'bob' })
 Intercom.updateUser({
     // Pre-defined user attributes
-    // (this attributes will be added in custom_attributes as duplicate)
     email: 'mimi@intercom.com',
     user_id: 'user_id',
     name: 'your name',

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -11,6 +11,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.ReadableMapKeySetIterator;
 import com.facebook.react.bridge.ReadableType;
 
+import java.sql.Date;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -223,7 +224,29 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         Map<String, Object> map = recursivelyDeconstructReadableMap(readableMap);
         UserAttributes.Builder builder = new UserAttributes.Builder();
         for (Map.Entry<String, Object> entry : map.entrySet()) {
-            builder.withCustomAttribute(entry.getKey(), entry.getValue());
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (key.equals("email")) {
+                builder.withEmail((String)value);
+            } else if (key.equals("user_id")) {
+                builder.withUserId((String)value);
+            } else if (key.equals("name")) {
+                builder.withName((String)value);
+            } else if (key.equals("phone")) {
+                builder.withPhone((String)value);
+            } else if (key.equals("language_override")) {
+                builder.withLanguageOverride((String)value);
+            } else if (key.equals("signed_up_at")) {
+                Date dateSignedUpAt = new Date((long)value);
+                builder.withSignedUpAt(dateSignedUpAt);
+            } else if (key.equals("unsubscribed_from_emails")) {
+                builder.withUnsubscribedFromEmails((Boolean)value);
+            } else if (key.equals("companies")) {
+                Log.w(TAG, "Not implemented yet");
+                // Note that this parameter is companies for iOS and company for Android
+            }
+
+            builder.withCustomAttribute(key, value);
         }
         return builder.build();
     }

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -241,12 +241,13 @@ public class IntercomModule extends ReactContextBaseJavaModule {
                 builder.withSignedUpAt(dateSignedUpAt);
             } else if (key.equals("unsubscribed_from_emails")) {
                 builder.withUnsubscribedFromEmails((Boolean)value);
+            } else if (key.equals("custom_attributes")) {
+                // value should be a Map here
+                builder.withCustomAttributes((Map)value);
             } else if (key.equals("companies")) {
                 Log.w(TAG, "Not implemented yet");
                 // Note that this parameter is companies for iOS and company for Android
             }
-
-            builder.withCustomAttribute(key, value);
         }
         return builder.build();
     }


### PR DESCRIPTION
## Summary 
- It closes #136.
- This is a patch for breaking change which resulted from a recent commit (https://github.com/tinycreative/react-native-intercom/commit/8916104d55f351e7ee7a26e027e8470370a072f6).
- In Android implementation, Intercom library does not update pre-defined user attributes (e.g., `email`, `name`) when using the updated UserAttribute.Builder.
- Instead, we need to call the designated methods such as `withName()`, `withEmail()` for the pre-defined user attributes. In iOS implementation, this is already implemented in a way as this pull request. 
- For `companies` attributes, we did not implement it because iOS and Android parameter name are different (`companies` for iOS and `company` for Android), accordingly, further discussion may be required later.
- One thing we want to note that for those properties, this will be also added to Custom Attributes because iOS was already implemented that way. We think that this is for backward compatibility of this library.

## Test
- Since we are using this logic in our app for production ("Mimiking" app), we confirmed that `name` and `email` is properly updated in our Intercom console with our actual app.

## Credit
- This work was done with @ghsdh3409 during our company's pair programming session.