### PR TITLE
Intercom reset deprecated

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -64,7 +64,7 @@ RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock)callback) {
     NSLog(@"reset");
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [Intercom reset];
+        [Intercom logout];
     });
 
     callback(@[[NSNull null]]);


### PR DESCRIPTION
As described in changelog below:
"Deprecate [Intercom reset] in favour of [Intercom logout]"
https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md