### PR TITLE
Add `~/Documents/Intercom` to FRAMEWORK_SEARCH_PATHS

### DIFF
--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"~/Documents/Intercom",
 					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (
@@ -241,6 +242,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
+					"~/Documents/Intercom",
 					"$(SRCROOT)/../../../ios/**",
 				);
 				HEADER_SEARCH_PATHS = (


### PR DESCRIPTION
Hey,

I am using `lerna` for `react-native` apps and there is an issue with `react-native-intercom`.  I am facing this error: https://github.com/tinycreative/react-native-intercom/issues/150.

To fix this issue, I followed [the way `react-native fbsdk` works](https://github.com/facebook/react-native-fbsdk/blob/master/ios/RCTFBSDK.xcodeproj/project.pbxproj#L366-L370) by adding an other item in `FRAMEWORK_SEARCH_PATHS`.

With this PR, we can put `Intercom` framework in `~/Documents/Intercom` dir.



