### PR TITLE
Changed framework search path to avoid `Argument list is too long`

### DIFF
--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -222,7 +222,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Pods/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -241,7 +241,7 @@
 			buildSettings = {
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SRCROOT)/../../../ios/**",
+					"$(SRCROOT)/../../../ios/Pods/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This PR solves the problem we end up having when using cocoapods and that the `/build` path will end up having too many children paths to look at and when xCode cant look up anymore it will throw the error:
`Argument list too long: recursive header expansion failed at  ....`

This PR aims to fix that by reducing the search space when xCode is looking up the dependencies for `RNIntercom`. This is based on other solutions:
https://github.com/evollu/react-native-firebase-analytics/commit/e8559a2f00eed245a771e5fdea228c8516d86cbd
https://github.com/Microsoft/AppCenter-SDK-React-Native/pull/211


Closes Issue #40