### PR TITLE
Added support for displaying Help Center

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -173,6 +173,12 @@ public class IntercomModule extends ReactContextBaseJavaModule {
         }
     }
 
+    @ReactMethod
+    public void displayHelpCenter(Callback callback) {
+        Intercom.client().displayHelpCenter();
+        callback.invoke(null, null);
+    }
+
     private Intercom.Visibility visibilityStringToVisibility(String visibility) {
       if (visibility.equalsIgnoreCase("VISIBLE")) {
         return Intercom.Visibility.VISIBLE;

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -163,6 +163,17 @@ RCT_EXPORT_METHOD(getUnreadConversationCount:(RCTResponseSenderBlock)callback) {
     callback(@[[NSNull null], unread_conversations]);
 }
 
+// Available as NativeModules.IntercomWrapper.displayHelpCenter
+RCT_EXPORT_METHOD(displayHelpCenter:(RCTResponseSenderBlock)callback) {
+    NSLog(@"displayHelpCenter");
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [Intercom presentHelpCenter];
+    });
+    
+    callback(@[[NSNull null]]);
+};
+
 // Available as NativeModules.IntercomWrapper.setLauncherVisibility
 RCT_EXPORT_METHOD(setLauncherVisibility:(NSString*)visibilityString callback:(RCTResponseSenderBlock)callback) {
     NSLog(@"setVisibility with %@", visibilityString);

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,12 @@ export function displayConversationsList(): Promise<void>;
 export function getUnreadConversationCount(): Promise<void>;
 
 /**
+ * displayHelpCenter
+ * @returns {Promise<void>}
+ */
+export function displayHelpCenter(): Promise<void>;
+
+/**
  * setLauncherVisibility
  * @param {string} visibility
  * @returns {Promise<void>}

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -228,6 +228,21 @@ class IntercomClient {
     );
   }
 
+  displayHelpCenter() {
+    return this._pushIntercomChain(
+      () =>
+        new Promise((resolve, reject) => {
+          IntercomWrapper.displayHelpCenter((error) => {
+            if (error) {
+              reject(error);
+            } else {
+              resolve();
+            }
+          });
+        }),
+    );
+  }
+
   setLauncherVisibility(visibility: String) {
     return this._pushIntercomChain(
       () =>


### PR DESCRIPTION
In iOS SDK 4.1.9 and Android SDK 4.1.7, Intercom exposed native methods for presenting the Help Center.

This PR provides access to these methods.