### PR TITLE
Update signed_up_at date parse to work on android

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -237,7 +237,7 @@ public class IntercomModule extends ReactContextBaseJavaModule {
             } else if (key.equals("language_override")) {
                 builder.withLanguageOverride((String)value);
             } else if (key.equals("signed_up_at")) {
-                Date dateSignedUpAt = new Date((long)value);
+                Date dateSignedUpAt = new Date(((Number)value).longValue());
                 builder.withSignedUpAt(dateSignedUpAt);
             } else if (key.equals("unsubscribed_from_emails")) {
                 builder.withUnsubscribedFromEmails((Boolean)value);


### PR DESCRIPTION
As @fryossi mention in [this comment](https://github.com/tinycreative/react-native-intercom/pull/137#issuecomment-357794697) when using `updateUser` on Android and passing in `signed_up_at` the update fails. This just changes what the code parses and make the update to work.

Let me know if I should provide some sort of test or something else. Really want to get this one merged. 