### PR TITLE
Fix podspec to work with use_frameworks! specification

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -13,6 +13,7 @@ Pod::Spec.new do |s|
   s.source_files = 'iOS/*.{h,m}'
   s.platform     = :ios, '8.0'
   s.frameworks   = [ "Intercom" ]
-
-  s.dependency 'Intercom', '~> 4.1.0'
+  s.static_framework = true
+  s.dependency 'React/Core'
+  s.dependency 'Intercom', '~> 4.1.9'
 end


### PR DESCRIPTION
Since `use_framework! ` specification is very common, it is necessary to add this type of specification to let react-native-intercom work properly.
Upgrading the dependency to 4.1.9 is necessary because, from Intercom pod version 4.1.9, Intercom.h exposes the method `presentHelpCenter` that is already exposed in `IntercomWrapper.m` and this leads to a compile error in every Intercom pod below 4.1.9