### PR TITLE
Upgrade Intercom SDKs to 5.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'io.intercom.android:intercom-sdk-base:4.+'
+    compile 'io.intercom.android:intercom-sdk-base:5.+'
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-intercom",
-  "version": "10.2.0",
+  "version": "10.3.0",
   "description": "A React Native client for Intercom.io",
   "main": "./lib/IntercomClient.js",
   "scripts": {

--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
   s.dependency 'React/Core'
-  s.dependency 'Intercom', '~> 4.1.9'
+  s.dependency 'Intercom', '~> 5.0.0'
 end


### PR DESCRIPTION
Intercom has released a new version of their messenger and support it
with a new version of their SDK.

The API has not changed so the upgrade path is a simple update of the
dependencies.