### PR TITLE
fix FRAMEWORK_SEARCH_PATHS when using carthage

### DIFF
--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 					"$(inherited)",
 					"~/Documents/Intercom",
 					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Carthage/Build/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
@@ -244,6 +245,7 @@
 					"$(inherited)",
 					"~/Documents/Intercom",
 					"$(SRCROOT)/../../../ios/Pods/**",
+					"$(SRCROOT)/../../../ios/Carthage/Build/**",
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
Due to this commit https://github.com/tinycreative/react-native-intercom/commit/8a77f788de0396b751559da01fe22943e45b205b the package is currently broken for users who are using carthage instead of cocoapods
