### PR TITLE
Define requiresMainQueueSetup to remove React Native warning

### DIFF
--- a/iOS/IntercomEventEmitter.m
+++ b/iOS/IntercomEventEmitter.m
@@ -40,4 +40,8 @@ RCT_EXPORT_MODULE();
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
++ (BOOL)requiresMainQueueSetup {
+    return YES;
+}
+
 @end


### PR DESCRIPTION
iOS app shows React Native yellow box warning that IntercomEventEmitter
requires main queue setup since it overrides 'constantsToExport'.
This commit defines the function to suppress the warning.

See issue 191: https://github.com/tinycreative/react-native-intercom/issues/191