### PR TITLE
Support new Intercom SDK (v5.1)

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
   s.dependency 'React/Core'
-  s.dependency 'Intercom', '~> 5.0.2'
+  s.dependency 'Intercom', '~> 5.0'
 end


### PR DESCRIPTION
Hi,

The new Intercom SDK has been released (v5.1).
It deprecated some methods but it has no breaking change. And globally the intercom sdks seem to be aligned in version and respect semver

Android already allows 5.*, but iOS is locked to 5.0. I think it makes sense to put both on 5.*, which my change is doing ([see](https://guides.cocoapods.org/syntax/podspec.html#dependency))

After that, a simple Gradle sync + `pod update Intercom` is enough to embed the new SDKs on both platforms, and according to my tests the new SDKs are working correctly with this lib (just modified the podspec locally and everything seems to work)


We should probably not expect any breaking change in 5.* (even on the deprecated methods which will probably break for 6.*), as there was never any breaking change without a major update:
https://github.com/intercom/intercom-ios/blob/master/CHANGELOG.md
https://github.com/intercom/intercom-android/blob/master/CHANGELOG.md

