### PR TITLE
Fix FRAMEWORK_SEARCH_PATHS when installing manually

### DIFF
--- a/iOS/RNIntercom.xcodeproj/project.pbxproj
+++ b/iOS/RNIntercom.xcodeproj/project.pbxproj
@@ -223,6 +223,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"~/Documents/Intercom",
+					"$(SRCROOT)/../../../ios/**",
 					"$(SRCROOT)/../../../ios/Pods/**",
 					"$(SRCROOT)/../../../ios/Carthage/Build/**",
 				);
@@ -244,6 +245,7 @@
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"~/Documents/Intercom",
+					"$(SRCROOT)/../../../ios/**",
 					"$(SRCROOT)/../../../ios/Pods/**",
 					"$(SRCROOT)/../../../ios/Carthage/Build/**",
 				);


### PR DESCRIPTION
Manual installation, Carthage, and CocoaPods are all supported.

Follow-up to #203