### PR TITLE
Update README.md regarding sendTokenToIntercom

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ _onUnreadChange = ({ count }) => {
     Intercom.Notifications.WINDOW_DID_HIDE
 ```
 
-### Send FCM token directly to Intercom
+### Send FCM token directly to Intercom for push notifications (Android only)
 ```
 Firebase.messaging().getToken()
   .then((token) => {


### PR DESCRIPTION
The `sendTokenToIntercom` method sends the Firebase Cloud Messaging (FCM) token to intercom for push notifications. 

However despite FCM can be used for push notifications on both Android and iOS, **Intercom only supports FCM tokens for Android** and not for iOS (where [APNs tokens should be used](https://developers.intercom.com/installing-intercom/docs/ios-push-notifications)), and that's why `sendTokenToIntercom` is [stubbed for iOS in this library](https://github.com/tinycreative/react-native-intercom/blob/374faecd21ffc46d2582ea4d6e97b2ae3f8f0211/iOS/IntercomWrapper.m#L44).

This generated a lot of confusion for us since we were expecting FCM to work cross-platform.

Also maybe `sendTokenToIntercom` should be renamed to `sendFCMTokenToIntercom`, as the current naming is too generic and doesn't even make clear that the token that will be sent is for push notifications and not any kind of authentication token for Intercom or the current user. I could make a PR for this if you guys think this make sense.