### PR TITLE
replace deprecated reset with logout method

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ Intercom.setUserHash(hash_received_from_backend)
 
 ### Sign Out
 ```javascript
-Intercom.reset()
+Intercom.logout()
 ```
 
 ### Show Message Composer

--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -80,9 +80,9 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void reset(@Nullable Callback callback) {
-        Intercom.client().reset();
-        Log.i(TAG, "reset");
+    public void logout(@Nullable Callback callback) {
+        Intercom.client().logout();
+        Log.i(TAG, "logout");
         if (callback != null) {
             callback.invoke(null, null);
         }

--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -59,9 +59,9 @@ RCT_EXPORT_METHOD(registerUnidentifiedUser:(RCTResponseSenderBlock)callback) {
     callback(@[[NSNull null]]);
 };
 
-// Available as NativeModules.IntercomWrapper.reset
-RCT_EXPORT_METHOD(reset:(RCTResponseSenderBlock)callback) {
-    NSLog(@"reset");
+// Available as NativeModules.IntercomWrapper.logout
+RCT_EXPORT_METHOD(logout:(RCTResponseSenderBlock)callback) {
+    NSLog(@"logout");
 
     dispatch_async(dispatch_get_main_queue(), ^{
         [Intercom logout];

--- a/index.d.ts
+++ b/index.d.ts
@@ -45,10 +45,10 @@ export function updateUser(attributes: {
 export function registerIdentifiedUser(options: { userId: string }): Promise<void>;
 
 /**
- * reset
+ * logout
  * @returns {Promise<void>}
  */
-export function reset(): Promise<void>;
+export function logout(): Promise<void>;
 
 /**
  * Log an event

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -95,11 +95,11 @@ class IntercomClient {
     );
   }
 
-  reset() {
+  logout() {
     return this._pushIntercomChain(
       () =>
         new Promise((resolve, reject) => {
-          IntercomWrapper.reset((error) => {
+          IntercomWrapper.logout((error) => {
             if (error) {
               reject(error);
             } else {


### PR DESCRIPTION
The "reset" is a deprecated method, so I replaced to "logout" on the calls, also updated the documentation. 