### PR TITLE
Update compileSdkVersion to 28

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     buildToolsVersion "26.0.1"
 
     defaultConfig {


### PR DESCRIPTION
We need to update the compileSdkVersion to 28 as the `io.intercom.android:intercom-sdk-base` project already moved to version 28 starting from [v5.1.6](https://github.com/intercom/intercom-android/commit/15bd88e62df552bc2f4135d332c70903c1c4a51b). Otherwise we would get a build error