### PR TITLE
Pin android-intercom to version 5.1.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.intercom.android:intercom-sdk-base:5.+'
+    implementation 'io.intercom.android:intercom-sdk-base:5.1.5'
 }
 


### PR DESCRIPTION
Version 5.1.6 of android-intercom use android sdk versions 28.x (compile/build/libcompat) which breaks projects using sdk version 27.x. It is recommended to build the project with the same sdk version as react-native use to avoid instability, which for the time being is version 27.x (RN 0.57.5).

fixes: #238 