### PR TITLE
Lock intercom-sdk-base into 5.1.5

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -34,6 +34,5 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.intercom.android:intercom-sdk-base:5.+'
+    implementation 'io.intercom.android:intercom-sdk-base:5.1.5'
 }
-


### PR DESCRIPTION
This build issues introduced by Intercom 5.1.6's move to android SDK version 28.

https://github.com/tinycreative/react-native-intercom/issues/238