### PR TITLE
add WINDOW_DID_SHOW_NOTIFICATION event

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,9 @@ _onUnreadChange = ({ count }) => {
 ```javascript
     // The window was hidden
     Intercom.Notifications.WINDOW_DID_HIDE
+
+    // The window was shown
+    Intercom.Notifications.WINDOW_DID_SHOW
 ```
 
 ### Send FCM token directly to Intercom for push notifications (Android only)

--- a/iOS/IntercomEventEmitter.m
+++ b/iOS/IntercomEventEmitter.m
@@ -32,18 +32,29 @@ RCT_EXPORT_MODULE();
   });
 }
 
+- (void)handleWindowDidShowNotification:(NSNotification *)notification {
+  __weak IntercomEventEmitter *weakSelf = self;
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.1 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+    IntercomEventEmitter *strongSelf = weakSelf;
+    [strongSelf sendEventWithName:IntercomWindowDidShowNotification body:@"Window Was Shown"];
+  });
+}
+
 - (NSDictionary<NSString *, NSString *> *)constantsToExport {
     return @{@"UNREAD_CHANGE_NOTIFICATION": IntercomUnreadConversationCountDidChangeNotification,
-             @"WINDOW_DID_HIDE_NOTIFICATION": IntercomWindowDidHideNotification};
+             @"WINDOW_DID_HIDE_NOTIFICATION": IntercomWindowDidHideNotification,
+             @"WINDOW_DID_SHOW_NOTIFICATION": IntercomWindowDidShowNotification
+         };
 }
 
 - (NSArray<NSString *> *)supportedEvents {
-    return @[IntercomUnreadConversationCountDidChangeNotification, IntercomWindowDidHideNotification];
+    return @[IntercomUnreadConversationCountDidChangeNotification, IntercomWindowDidHideNotification, IntercomWindowDidShowNotification];
 }
 
 -(void)startObserving {
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleUpdateUnreadCount:) name:IntercomUnreadConversationCountDidChangeNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleWindowDidHideNotification:) name:IntercomWindowDidHideNotification object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleWindowDidShowNotification:) name:IntercomWindowDidShowNotification object:nil];
 }
 
 - (void)stopObserving {

--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -16,7 +16,8 @@ class IntercomClient {
 
   Notifications = {
     UNREAD_COUNT: IntercomEventEmitter.UNREAD_CHANGE_NOTIFICATION,
-    WINDOW_DID_HIDE: IntercomEventEmitter.WINDOW_DID_HIDE_NOTIFICATION
+    WINDOW_DID_HIDE: IntercomEventEmitter.WINDOW_DID_HIDE_NOTIFICATION,
+    WINDOW_DID_SHOW: IntercomEventEmitter.WINDOW_DID_SHOW_NOTIFICATION
   };
 
   _eventEmitter;
@@ -27,7 +28,8 @@ class IntercomClient {
   constructor() {
     this._eventHandlers = {
       [IntercomEventEmitter.UNREAD_CHANGE_NOTIFICATION]: new Map(),
-      [IntercomEventEmitter.WINDOW_DID_HIDE_NOTIFICATION]: new Map()
+      [IntercomEventEmitter.WINDOW_DID_HIDE_NOTIFICATION]: new Map(),
+      [IntercomEventEmitter.WINDOW_DID_SHOW_NOTIFICATION]: new Map()
     };
 
     // the first item in the chain needs to be a succesfull promise


### PR DESCRIPTION
Complements the `WINDOW_DID_HIDE` event. Useful for tracking and analytics.