### PR TITLE
expose Intercom.Visibility

### DIFF
--- a/lib/IntercomClient.js
+++ b/lib/IntercomClient.js
@@ -9,7 +9,7 @@ const { IntercomWrapper, IntercomEventEmitter } = NativeModules;
  */
 
 class IntercomClient {
-  static Visibility = {
+  Visibility = {
     VISIBLE: 'VISIBLE',
     GONE: 'GONE',
   };


### PR DESCRIPTION
I think there is a mistake either with the type or with how the class expose the Visibility enum.

This allows to do `Intercom.Visibility.VISIBLE` . Which is probably expected since it's how the Notifications enum is accessed.