### PR TITLE
[podfile] Depend on React instead of React/Core

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
-  s.dependency 'React/Core'
+  s.dependency 'React'
   s.dependency 'Intercom', '~> 5.0'
 end


### PR DESCRIPTION
The structure of podfiles was recently changed in react-native so React/Core no longer exists. To be safer we can just depend on the React one instead which should never change.