### PR TITLE
Fix iOS device token conversion in setupAPN

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -201,7 +201,22 @@ RCT_EXPORT_METHOD(setInAppMessageVisibility:(NSString*)visibilityString resolver
 // Available as NativeModules.IntercomWrapper.setupAPN
 RCT_EXPORT_METHOD(setupAPN:(NSString*)deviceToken resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     NSLog(@"setupAPN with %@", deviceToken);
-    [Intercom setDeviceToken:[deviceToken dataUsingEncoding:NSUTF8StringEncoding]];
+
+    // Convert device token hex string back to initial NSData format
+    // as received in -application:didRegisterForRemoteNotificationsWithDeviceToken:
+    // that is expected by -setDeviceToken:
+    NSMutableData *deviceTokenData = [NSMutableData new];
+    unsigned char whole_byte;
+    char byte_chars[3] = {'\0','\0','\0'};
+    int i;
+    for (i=0; i < [deviceToken length] / 2; i++) {
+      byte_chars[0] = [deviceToken characterAtIndex:i*2];
+      byte_chars[1] = [deviceToken characterAtIndex:i*2+1];
+      whole_byte = strtol(byte_chars, NULL, 16);
+      [deviceTokenData appendBytes:&whole_byte length:1];
+    }
+
+    [Intercom setDeviceToken:deviceTokenData];
     resolve([NSNull null]);
 };
 


### PR DESCRIPTION
Device token encoding in `setupAPN` is not working, [as mentioned here](https://github.com/tinycreative/react-native-intercom/issues/23#issuecomment-233843184)

This PR fixes device token encoding from hex string back to the initial NSData format as received in application delegate. Based on [this response on SO](https://stackoverflow.com/questions/41555543/how-to-convert-ios-device-token-string-back-to-nsdata).