### PR TITLE
Expand metadata types for events to what Intercom supports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,9 +63,9 @@ export function logout(): Promise<void>;
 /**
  * Log an event
  * @param {string} eventName
- * @param {[key: string]: string} metadata
+ * @param {[key: string]: string | number | boolean } metadata
  */
-export function logEvent(eventName: string, metadata: { [key: string]: string }): Promise<void>;
+export function logEvent(eventName: string, metadata: { [key: string]: string | number | boolean }): Promise<void>;
 
 /**
  * handlePushMessage


### PR DESCRIPTION
The intercom SDKs allow you to give a couple more types than `String` for the metadata when doing a `logEvent`. This adds support for `number` and `boolean`. 

There may be other ones that may be beneficial to add in the future like Date that you can find [here](https://developers.intercom.com/intercom-api-reference/reference#event-metadata-types), but I left those for some other time. 