### PR TITLE
Register both user id and email on Android's registerIdentifiedUser

### DIFF
--- a/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
+++ b/android/src/main/java/com/robinpowered/react/Intercom/IntercomModule.java
@@ -45,13 +45,21 @@ public class IntercomModule extends ReactContextBaseJavaModule {
     @ReactMethod
     public void registerIdentifiedUser(ReadableMap options, Promise promise) {
         try {
-            if (options.hasKey("email") && options.getString("email").length() > 0) {
+            Boolean hasEmail = options.hasKey("email") && options.getString("email").length() > 0;
+            Boolean hasUserId = options.hasKey("userId") && options.getString("userId").length() > 0;
+            if (hasEmail && hasUserId) {
+                Intercom.client().registerIdentifiedUser(
+                        new Registration().withEmail(options.getString("email")).withUserId(options.getString("userId"))
+                );
+                Log.i(TAG, "registerIdentifiedUser with userEmail");
+                promise.resolve(null);
+            } else if (hasEmail) {
                 Intercom.client().registerIdentifiedUser(
                         new Registration().withEmail(options.getString("email"))
                 );
                 Log.i(TAG, "registerIdentifiedUser with userEmail");
                 promise.resolve(null);
-            } else if (options.hasKey("userId") && options.getString("userId").length() > 0) {
+            } else if (hasUserId) {
                 Intercom.client().registerIdentifiedUser(
                         new Registration().withUserId(options.getString("userId"))
                 );


### PR DESCRIPTION
This matches current iOS implementation of `registerIdentifiedUser` on `IntercomWrapper.m`.