### PR TITLE
`WINDOW_DID_SHOW` added to type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,7 @@ type VisibilityType = IVisibility[keyof IVisibility];
 
 interface INotifications {
   UNREAD_COUNT: 'UNREAD_CHANGE_NOTIFICATION';
+  WINDOW_DID_SHOW: 'WINDOW_DID_SHOW';
   WINDOW_DID_HIDE: 'WINDOW_DID_HIDE';
 }
 declare const Notifications: INotifications;


### PR DESCRIPTION
added missed constant
should fix ts errors;

--- 
fixes #331;