### PR TITLE
Update Intercom to v6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-intercom",
-  "version": "14.1.0",
+  "version": "15.1.0",
   "description": "A React Native client for Intercom.io",
   "main": "./lib/IntercomClient.js",
   "scripts": {

--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
   s.dependency 'React'
-  s.dependency 'Intercom', '~> 6.0.0'
+  s.dependency 'Intercom', '~> 6.1.0'
 end


### PR DESCRIPTION
Bumping Intercom to v6.1.0 to get the ability to disable message composer which is new in v6.1.0.