### PR TITLE
intercom sdk to 7.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'io.intercom.android:intercom-sdk-base:6.+'
+    implementation 'io.intercom.android:intercom-sdk-base:7.+'
 }
 

--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
   s.dependency 'React'
-  s.dependency 'Intercom', '~> 6.1.0'
+  s.dependency 'Intercom', '~> 7.1.0'
 end


### PR DESCRIPTION
fix https://github.com/tinycreative/react-native-intercom/issues/372

to be noted intercom SDK on iOS needs XCode 11.4+