### PR TITLE
DOC: Remove duplicate "display help center" entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,11 +297,6 @@ Intercom.displayMessenger();
 Intercom.displayConversationsList();
 ```
 
-### Display Help Center
-```javascript
-Intercom.displayHelpCenter();
-```
-
 ### Set Bottom Padding
 ```javascript
 Intercom.setBottomPadding(64);


### PR DESCRIPTION
Just found out a small typo in the readme, I guess it can't hurt to fix it :-)