### PR TITLE
Fix UI API called on a background thread on iOS

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -106,10 +106,9 @@ RCT_EXPORT_METHOD(handlePushMessage :(RCTPromiseResolveBlock)resolve :(RCTPromis
 RCT_EXPORT_METHOD(displayMessenger :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject) {
     NSLog(@"displayMessenger");
     
-    UIViewController *controller = RCTPresentedViewController();
-    [RCTUtilsUIOverride setPresentedViewController:controller];
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        [RCTUtilsUIOverride setPresentedViewController:controller];
         [Intercom presentMessenger];
     });
 
@@ -131,10 +130,9 @@ RCT_EXPORT_METHOD(hideMessenger :(RCTPromiseResolveBlock)resolve :(RCTPromiseRej
 RCT_EXPORT_METHOD(displayMessageComposer :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject) {
     NSLog(@"displayMessageComposer");
     
-    UIViewController *controller = RCTPresentedViewController();
-    [RCTUtilsUIOverride setPresentedViewController:controller];
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        [RCTUtilsUIOverride setPresentedViewController:controller];
         [Intercom presentMessageComposer];
     });
 
@@ -144,10 +142,9 @@ RCT_EXPORT_METHOD(displayMessageComposer :(RCTPromiseResolveBlock)resolve :(RCTP
 RCT_EXPORT_METHOD(displayMessageComposerWithInitialMessage:(NSString*)message resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     NSLog(@"displayMessageComposerWithInitialMessage");
     
-    UIViewController *controller = RCTPresentedViewController();
-    [RCTUtilsUIOverride setPresentedViewController:controller];
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        [RCTUtilsUIOverride setPresentedViewController:controller];
         [Intercom presentMessageComposerWithInitialMessage:message];
     });
 
@@ -158,10 +155,9 @@ RCT_EXPORT_METHOD(displayMessageComposerWithInitialMessage:(NSString*)message re
 RCT_EXPORT_METHOD(displayConversationsList :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject) {
     NSLog(@"displayConversationsList");
     
-    UIViewController *controller = RCTPresentedViewController();
-    [RCTUtilsUIOverride setPresentedViewController:controller];
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        [RCTUtilsUIOverride setPresentedViewController:controller];
         [Intercom presentConversationList];
     });
 
@@ -181,10 +177,9 @@ RCT_EXPORT_METHOD(getUnreadConversationCount :(RCTPromiseResolveBlock)resolve :(
 RCT_EXPORT_METHOD(displayHelpCenter :(RCTPromiseResolveBlock)resolve :(RCTPromiseRejectBlock)reject) {
     NSLog(@"displayHelpCenter");
     
-    UIViewController *controller = RCTPresentedViewController();
-    [RCTUtilsUIOverride setPresentedViewController:controller];
-
     dispatch_async(dispatch_get_main_queue(), ^{
+        UIViewController *controller = RCTPresentedViewController();
+        [RCTUtilsUIOverride setPresentedViewController:controller];
         [Intercom presentHelpCenter];
     });
 


### PR DESCRIPTION
When opening the messenger on iOS, it take few seconds to open and the following error is logged several time.
This seems to have been introduce with this commit: https://github.com/tinycreative/react-native-intercom/commit/d1655faafde23e646a91592cff56fdefbe6e33dc

```
Main Thread Checker: UI API called on a background thread: -[UIApplication windows]
PID: 6662, TID: 3056615, Thread name: (none), Queue name: com.facebook.react.IntercomWrapperQueue, QoS: 0
Backtrace:
4   TestApp                            0x0000000100e81868 RCTKeyWindow + 116
5   TestApp                            0x0000000100e81a60 RCTPresentedViewController + 104
6   TestApp                            0x0000000101300b94 -[IntercomWrapper displayMessenger::] + 100
7   CoreFoundation                      0x00000001a82c75d4 52963DBA-FA89-36C2-8262-28B9776F8C12 + 1205716
8   CoreFoundation                      0x00000001a81a29e8 52963DBA-FA89-36C2-8262-28B9776F8C12 + 6632
9   CoreFoundation                      0x00000001a81a2fa4 52963DBA-FA89-36C2-8262-28B9776F8C12 + 8100
10  TestApp                            0x0000000100e13294 -[RCTModuleMethod invokeWithBridge:module:arguments:] + 1880
11  TestApp                            0x0000000100e1695c _ZN8facebook5reactL11invokeInnerEP9RCTBridgeP13RCTModuleDatajRKN5folly7dynamicE + 648
12  TestApp                            0x0000000100e16510 _ZZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEiENK3$_0clEv + 128
13  TestApp                            0x0000000100e16484 ___ZN8facebook5react15RCTNativeModule6invokeEjON5folly7dynamicEi_block_invoke + 28
14  libdispatch.dylib                   0x0000000104137b68 _dispatch_call_block_and_release + 32
15  libdispatch.dylib                   0x00000001041395f0 _dispatch_client_callout + 20
16  libdispatch.dylib                   0x0000000104140fa8 _dispatch_lane_serial_drain + 736
17  libdispatch.dylib                   0x0000000104141cb4 _dispatch_lane_invoke + 448
18  libdispatch.dylib                   0x000000010414de38 _dispatch_workloop_worker_thread + 1520
19  libsystem_pthread.dylib             0x00000001f01b3908 _pthread_wqthread + 276
20  libsystem_pthread.dylib             0x00000001f01ba77c start_wqthread + 8
```