### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '10.0'
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'Intercom', '~> 9.3.6'
 end


### PR DESCRIPTION
# Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: facebook/react-native#29633 (comment)