### PR TITLE
Intercom 10 for iOS (closes #457)

### DIFF
--- a/iOS/IntercomWrapper.m
+++ b/iOS/IntercomWrapper.m
@@ -134,7 +134,7 @@ RCT_EXPORT_METHOD(hideMessenger :(RCTPromiseResolveBlock)resolve :(RCTPromiseRej
     NSLog(@"hideMessenger");
 
     dispatch_async(dispatch_get_main_queue(), ^{
-        [Intercom hideMessenger];
+        [Intercom hideIntercom];
     });
 
     resolve([NSNull null]);

--- a/react-native-intercom.podspec
+++ b/react-native-intercom.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
   s.frameworks   = [ "Intercom" ]
   s.static_framework = true
   s.dependency 'React'
-  s.dependency 'Intercom', '~> 9.3.6'
+  s.dependency 'Intercom', '~> 10'
 end


### PR DESCRIPTION
As per the documentation here:

https://github.com/intercom/intercom-ios/releases/tag/10.0.0

`hideMessenger` has been removed and renamed to `hideIntercom` which I have fixed in the internal native bridge

I have kept the RN library's methods the same so there are no breaking external changes for users of this library.