### PR TITLE
Fixes bad gateway error on android build 463

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -30,9 +30,15 @@ android {
 }
 
 repositories {
+    mavenLocal()
     mavenCentral()
     maven {
-      url 'https://dl.bintray.com/intercom/intercom-maven'
+        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
+        url "$rootDir/../node_modules/react-native/android"
+    }
+    maven {
+        // Android JSC is installed from npm
+        url "$rootDir/../node_modules/jsc-android/dist"
     }
 }
 


### PR DESCRIPTION
Fixes #463  error where attempting to build results in a 502 gateway error due to bintray maven respositories being deprecated